### PR TITLE
Added redirects from old URLs to new URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,3 +26,6 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       layout: "page"
+
+gems:
+  - jekyll-redirect-from

--- a/cs/changelog.md
+++ b/cs/changelog.md
@@ -1,5 +1,6 @@
 ---
 title: Changelog
+redirect_from: "/changelog"
 ---
 
 ## [3.1.1](https://github.com/Tharos/LeanMapper/tree/v3.1.1) (10. 7. 2016)

--- a/cs/docs/entity.md
+++ b/cs/docs/entity.md
@@ -1,5 +1,6 @@
 ---
 title: Entity
+redirect_from: "/dokumentace/entity"
 ---
 
 * [Úvod](#page-title)

--- a/cs/docs/filtry.md
+++ b/cs/docs/filtry.md
@@ -1,5 +1,6 @@
 ---
 title: Filtry
+redirect_from: "/dokumentace/filtry"
 ---
 
 *Kapitola bude zpracována v rámci dokumentace pro vyšší stable verzi Lean Mapperu.*

--- a/cs/docs/konvence.md
+++ b/cs/docs/konvence.md
@@ -1,5 +1,6 @@
 ---
 title: Konvence
+redirect_from: "/dokumentace/konvence"
 ---
 
 Lean Mapper se vám bude velmi dobře používat, pokud budete v maximální možné míře dodržovat následující konvence:

--- a/cs/docs/persistence.md
+++ b/cs/docs/persistence.md
@@ -1,5 +1,6 @@
 ---
 title: Persistence
+redirect_from: "/dokumentace/persistence"
 ---
 
 * [Úvod](#page-title)

--- a/cs/docs/repositare.md
+++ b/cs/docs/repositare.md
@@ -1,5 +1,6 @@
 ---
 title: Repositáře
+redirect_from: "/dokumentace/repositare"
 ---
 
 * [Úvod](#page-title)

--- a/cs/donate.md
+++ b/cs/donate.md
@@ -1,5 +1,6 @@
 ---
 title: Podpořte vývoj
+redirect_from: "/donate"
 ---
 
 Lean Mapper můžete zcela zdarma používat ve svých komerčních i nekomerčních projektech.

--- a/cs/download.md
+++ b/cs/download.md
@@ -1,5 +1,6 @@
 ---
 title: Download
+redirect_from: "/download"
 ---
 
 LeanMapper je primárně dostupný přes [Packagist](https://packagist.org/packages/tharos/leanmapper).

--- a/cs/index.md
+++ b/cs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Dokumentace
+redirect_from: "/dokumentace/"
 ---
 
 * [Quick start](/cs/quick-start/)

--- a/cs/quick-start/index.md
+++ b/cs/quick-start/index.md
@@ -1,5 +1,6 @@
 ---
 title: Quick start
+redirect_from: "/quick-start/"
 ---
 
 Quick start se sestává z pěti krátkých kapitol, které vám představí, jak Lean Mapper funguje a jak se používá.

--- a/cs/quick-start/kapitola-1.md
+++ b/cs/quick-start/kapitola-1.md
@@ -1,5 +1,6 @@
 ---
 title: Kapitola I – Instalace
+redirect_from: "/quick-start/kapitola-1"
 ---
 
 Doporučený způsob instalace je pomocí [Composeru](http://getcomposer.org/):

--- a/cs/quick-start/kapitola-2.md
+++ b/cs/quick-start/kapitola-2.md
@@ -1,5 +1,6 @@
 ---
 title: Kapitola II – Vytvoření databáze
+redirect_from: "/quick-start/kapitola-2"
 ---
 
 V quick startu budeme pracovat s SQLite databází s následující strukturou:

--- a/cs/quick-start/kapitola-3.md
+++ b/cs/quick-start/kapitola-3.md
@@ -1,5 +1,6 @@
 ---
 title: Kapitola III – Definice entit
+redirect_from: "/quick-start/kapitola-3"
 ---
 
 * [Úvod](#page-title)

--- a/cs/quick-start/kapitola-4.md
+++ b/cs/quick-start/kapitola-4.md
@@ -1,5 +1,6 @@
 ---
 title: Kapitola IV – Definice repositářů
+redirect_from: "/quick-start/kapitola-4"
 ---
 
 Jak už jeho název napovídá, Lean Mapper je silně inspirován návrhovým vzorem Data Mapper. Proto se v něm entity **neumějí samy vytvářet, persistovat, mazat a v podstatě ani načítat** (načítání je tak trochu výjimkou, protože entita si dokáže sama načíst entity, ke kterým má nadefinovanou vazbu). To je důvod, proč potřebujeme repositáře.

--- a/cs/quick-start/kapitola-5.md
+++ b/cs/quick-start/kapitola-5.md
@@ -1,5 +1,6 @@
 ---
 title: Kapitola V – Ukázky použití (a položených SQL dotazů)
+redirect_from: "/quick-start/kapitola-5"
 ---
 
 * [Úvod](#page-title)


### PR DESCRIPTION
Přidáno přesměrování starých URL (z leanmapper.com) na nové. Např. stará URL `/dokumentace/entity` je přesměrována na nové `/cs/docs/entity/`.

Souvisí s #12.