### PR TITLE
Drobné úpravy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # Site settings
 title: Lean Mapper
 email: miras.paulik@seznam.cz
-description: Lean Mapper is a tiny ORM based on powerful dibi database abstraction library for PHP.
+description: Lean Mapper is a tiny ORM based on powerful Dibi database abstraction library for PHP.
 baseurl: "" # the subpath of your site, e.g. /blog
 #url: "http://yourdomain.com" # the base hostname & protocol for your site
 twitter_username: MiraPaulik

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <h1 class="project-name">Lean Mapper</h1>
-<h2 class="project-tagline">Lean Mapper je malé ORM postavené nad knihovnou dibi (abstraktní databázovou vrstvou pro PHP)</h2>
+<h2 class="project-tagline">Lean Mapper je malé ORM postavené nad knihovnou Dibi (abstraktní databázovou vrstvou pro PHP)</h2>
 <a class="btn" href="{{ '/' | prepend: site.baseurl }}">Úvod</a>
 <a class="btn" href="{{ '/cs/' | prepend: site.baseurl }}">Dokumentace</a>
 <a class="btn" href="{{ '/cs/quick-start/' | prepend: site.baseurl }}">Quick start</a>

--- a/cs/api.md
+++ b/cs/api.md
@@ -2,6 +2,7 @@
 title: API dokumentace
 ---
 
+* [Vývojová verze](https://codedoc.pub/tharos/leanmapper/develop/index.html)
 * [3.1.1](https://codedoc.pub/tharos/leanmapper/v3.1.1/index.html)
 * [3.1.0](https://codedoc.pub/tharos/leanmapper/v3.1.0/index.html)
 * [3.0.0](https://codedoc.pub/tharos/leanmapper/v3.0.0/index.html)

--- a/cs/docs/entity.md
+++ b/cs/docs/entity.md
@@ -324,6 +324,9 @@ U dovětků platí, že jejich jednotlivé části jsou odděleny dvojtečkou a 
 | OrderDetail $detail m:belongsToOne | OrderDetail $detail m:belongsToOne(order_id:orderdetail)
 
 
+U vazeb `hasMany`, `belongsToMany` a `belongsToOne` je možné uvést dodatek `#union` - jeho význam vysvětluje kapitola [SQL strategie](../sql-strategie/).
+
+
 ## Příznaky {#toc-priznaky}
 
 U každé položky zapsané v anotaci můžeme uvést celou řadu doplňujících příznaků.

--- a/cs/docs/integrace-do-aplikace.md
+++ b/cs/docs/integrace-do-aplikace.md
@@ -27,7 +27,7 @@ $connection = new LeanMapper\Connection(array(
 ));
 ```
 
-**Tip:** `LeanMapper\Connection` přebírá stejné parametry jako třída [`DibiConnection`](https://api.dibiphp.com/3.0/Dibi.Connection.html).
+**Tip:** `LeanMapper\Connection` přebírá stejné parametry jako třída [`Dibi\Connection`](https://api.dibiphp.com/Dibi.Connection.html).
 
 
 ## Mapper  {#toc-mapper}

--- a/cs/docs/integrace-do-aplikace.md
+++ b/cs/docs/integrace-do-aplikace.md
@@ -130,7 +130,7 @@ class BookPresenter extends BasePresenter {
 ```
 
 
-Alternativně lze pro předání repositáře do presenteru můžeme využít anotaci [`@inject`](https://doc.nette.org/cs/2.4/presenters#toc-pouziti-modelovych-trid).
+Alternativně můžeme použít anotaci [`@inject`](https://doc.nette.org/cs/2.4/presenters#toc-pouziti-modelovych-trid).
 
 ``` php?start_inline=1
 class BookPresenter extends BasePresenter {

--- a/cs/docs/system-udalosti.md
+++ b/cs/docs/system-udalosti.md
@@ -13,7 +13,7 @@ title: Systém událostí
 
 ## Registrace událostí {#toc-registrace}
 
-Jako obsluhu události vždy registrujeme nějaký callback - může se jednat o anonymní funkci, metodu objektu apod. Každá zaregistrovaná obslužná funkce dostane jako parametr entitu, se kterou se pracuje.
+Jako obsluhu události vždy registrujeme nějaký callback - může se jednat o anonymní funkci, metodu objektu apod. Každá zaregistrovaná obslužná funkce dostane jako parametr entitu, se kterou se pracuje. Výjimku tvoří události `onBeforeDelete` a `onAfterDelete`, které kromě entity akceptují i ID databázového záznamu.
 
 ``` php?start_inline=1
 $authorRepository = new AuthorRepository($connection, $mapper, $entityFactory);

--- a/cs/index.md
+++ b/cs/index.md
@@ -22,4 +22,4 @@ redirect_from: "/dokumentace/"
 * [Články a videa](/cs/clanky-videa/)
 * [Podpořte vývoj](/cs/donate/)
 * [API dokumentace](/cs/api/)
-* [Fórum](https://forum.dibiphp.com/cs/f82-lean-mapper), [Gitter](https://gitter.im/castamir/LeanMapperChat), [Slack](https://pehapkari.slack.com/messages/leanmapper)
+* [Fórum](https://leanmapper-forum.intm.org/), [Fórum (staré)](https://forum.dibiphp.com/cs/f82-lean-mapper), [Gitter](https://gitter.im/castamir/LeanMapperChat), [Slack](https://pehapkari.slack.com/messages/leanmapper)

--- a/cs/quick-start/kapitola-3.md
+++ b/cs/quick-start/kapitola-3.md
@@ -76,7 +76,7 @@ class Book extends \LeanMapper\Entity
 }
 ```
 
-***TIP:** SQLite, které v quick startu používáme, nemá samostatný datový typ pro datum a čas a i knihovna dibi vrací při použití SQLite driveru datum a čas jako textový řetězec. Samozřejmě by bylo možné (a i vhodné) nadefinovat v této entitě položku pubdate pomocí metod obsahujících konverzi z/do DateTime, ale v quick startu nebudeme do takových detailů zacházet. Dodejme, že celá věc by byla snazší při použití databáze MySQL a MySQL dibi driveru, který datum vrací jako instanci DibiDateTime.*
+***TIP:** SQLite, které v quick startu používáme, nemá samostatný datový typ pro datum a čas a i knihovna Dibi vrací při použití SQLite driveru datum a čas jako textový řetězec. Samozřejmě by bylo možné (a i vhodné) nadefinovat v této entitě položku pubdate pomocí metod obsahujících konverzi z/do DateTime, ale v quick startu nebudeme do takových detailů zacházet. Dodejme, že celá věc by byla snazší při použití databáze MySQL a MySQL Dibi driveru, který datum vrací jako instanci Dibi\DateTime.*
 
 
 ### 1:N vazby

--- a/index.md
+++ b/index.md
@@ -4,8 +4,8 @@ layout: default
 
 # Co je Lean Mapper
 
-- **Tenké ORM pro PHP postavené nad knihovnou [dibi](https://dibiphp.com)**
-<br> Prověřená a výkonná knihovna dibi poskytuje Lean Mapperu *stabilní půdu pod nohama* a umožňuje psát kód pro *širokou řadu databázových systémů*.
+- **Tenké ORM pro PHP postavené nad knihovnou [Dibi](https://dibiphp.com)**
+<br> Prověřená a výkonná knihovna Dibi poskytuje Lean Mapperu *stabilní půdu pod nohama* a umožňuje psát kód pro *širokou řadu databázových systémů*.
 
 - **ORM, které sestavuje elegantní a efektivní SQL dotazy**
 <br> Lean Mapper je silně inspirován knihovnou [NotORM](http://www.notorm.com) a obsahuje vlastní minimalistickou implementaci „NotORM principu“ (stahování souvisejících záznamů pro celý výsledek najednou místo jednotlivě).
@@ -14,7 +14,7 @@ layout: default
 <br> Stabilita a bezchybná funkčnost má při vývoji Lean Mapperu *nejvyšší prioritu*. Každá vydaná verze je označena kódem ve tvaru X.Y.Z a platí, že *změny v rámci řady Z jsou vždy zpětně kompatibilní*. Opravné balíčky jsou *vždy portovány do všech chybou dotčených řad X a Y*.
 
 - **Knihovna s minimem závislostí**
-<br> Jedinou závislostí Lean Mapperu je [dibi](https://dibiphp.com).
+<br> Jedinou závislostí Lean Mapperu je [Dibi](https://dibiphp.com).
 
 
 # Co Lean Mapper není


### PR DESCRIPTION
* slovo "dibi" změněno na "Dibi"
* aktualizovány názvy Dibi tříd (`DibiConnection` => `Dibi\Connection`, apod.)
* oprava a přepsání jedné věty na stránce Integrace do aplikace
* na stránku Systém událostí přidána zmínka, že události beforeDelete a afterDelete mohou místo entity obdržet pouze ID (protože `Repository::delete()` akceptuje i ID záznamu)
* na stránku API dokumentace přidán odkaz na `develop` verzi
* na stránku Entity do sekce Definice vazeb přidána zmínka o `#union` a odkaz na stránku SQL strategie
* odkaz na Dibi fórum označen za "zastaralý", přidán odkaz na "nové" fórum