### PR TITLE
Úpravy 2018-07-08

### DIFF
--- a/cs/changelog.md
+++ b/cs/changelog.md
@@ -5,6 +5,13 @@ redirect_from: "/changelog"
 
 ## [Vývojová verze](https://github.com/Tharos/LeanMapper/tree/develop)
 
+* Vazby `belongsTo` jsou označeny jako pouze pro čtení ([#124](https://github.com/Tharos/LeanMapper/pull/124), [#62](https://github.com/Tharos/LeanMapper/issues/62))
+
+* Přidána podpora pro `m:hasMany(#inversed)` ([#125](https://github.com/Tharos/LeanMapper/pull/125), [#123](https://github.com/Tharos/LeanMapper/issues/123))
+
+* Přidána podpora pro víceřádkové anotace ([#108](https://github.com/Tharos/LeanMapper/pull/122), [#29](https://github.com/Tharos/LeanMapper/issues/29))
+
+
 ## [3.2.0](https://github.com/Tharos/LeanMapper/tree/v3.2.0) (1. 5. 2018)
 
 * Hodnota příznaku v anotacích může nyní obsahovat zanořené závorky (např. `m:default(array())`) ([#122](https://github.com/Tharos/LeanMapper/pull/122))

--- a/cs/docs/entity.md
+++ b/cs/docs/entity.md
@@ -105,7 +105,7 @@ U této položky jsme poprvé použili sufix `|null` u definice typu, který ř�
 @property Tag[] $tags m:hasMany
 ```
 
-Položka s názem `tags` je zajímavá dvěmi věcmi: sufixem `[]` v definici typu, který říká, že položka obsahuje pole instancí `Tag` (anebo volitelně nějakou kolekci instancí `Tag`) instancí `Tag`, a také je zajímavá příznakem `m:hasMany`, který definuje M:N vazbu mezi entitami `Book` a `Tag`.
+Položka s názem `tags` je zajímavá dvěmi věcmi: sufixem `[]` v definici typu, který říká, že položka obsahuje pole instancí `Tag` (anebo volitelně nějakou kolekci instancí `Tag`), a také je zajímavá příznakem `m:hasMany`, který definuje M:N vazbu mezi entitami `Book` a `Tag`.
 
 ```
 @property string $title  Name of the book

--- a/cs/docs/filtry.md
+++ b/cs/docs/filtry.md
@@ -286,7 +286,7 @@ $books = $author->books;
 
 Nejprve definujeme entity `Book` a `Author`, poté si vytvoříme obecný filtr `CommonFilter::restrictAvailables`. Nejdůležitější je v tomto případě vlastní mapper - v něm definujeme metodu `getImplicitFilters`, která pro entitu `Book` vytvoří instanci objektu `LeanMapper\ImplicitFilters` - té předá nejprve seznam filtrů (zde pouze filtr `restrictAvailables`) a následně i adresovaný parametr s názvem tabulky, na kterou má být omezení aplikováno. Díky tomu nám bude volání `$author->books` vždy vracet jenom dostupné knihy.
 
-Metoda `getImplicitFilters` může kromě názvu entity obdržet ještě nepovinný parametr `$caller`. Implicitní filtry jsou obvykle aplikovány při volání metody `Repository::createFluent` - pak parametr `$caller` obsahuje odkaz na repositář, nebo při traverzování mezi entitami - v tom případě parametr `$caller` obsahuje odkaz na entitu a název property, přes kterou se traverzuje.
+Metoda `getImplicitFilters` může kromě názvu entity obdržet ještě nepovinný parametr `$caller`. Implicitní filtry jsou obvykle aplikovány při volání metody `Repository::createFluent` - pak parametr `$caller` obsahuje odkaz na repositář, nebo při traverzování mezi entitami - v tom případě parametr `$caller` obsahuje odkaz na entitu a property, přes kterou se traverzuje.
 
 
 ## Objekt Filtering - anonymní filtry {#toc-objekt-filtering}

--- a/cs/docs/filtry.md
+++ b/cs/docs/filtry.md
@@ -227,7 +227,7 @@ Výše uvedený příklad načte pomocí `$book->tags` prvních 10 tagů souvise
 
 ## Implicitní filtry {#toc-implicitni-filtry}
 
-Výchozí, neboli implicitní, filtry jsou takové filtry, které budou aplikovány vždy bez ohledu na to, jestli jsou uvedeny v příznaku `m:filter`, či nikoli. Implicitní filtry se spouští z repozitáře v rámci metody `LeanMapper\Repository::createFluent()` - kvůli tomu nemůžou obdržet parametry předávané pomocí [auto-wiringu](#toc-parametry-filtru-auto-wiring). Využití naleznou např. pro soft-deleted entity a další podobné případy.
+Výchozí, neboli implicitní, filtry jsou takové filtry, které budou aplikovány vždy bez ohledu na to, jestli jsou uvedeny v příznaku `m:filter`, či nikoli. Implicitní filtry se spouští při traverzování mezi entitami a z repozitáře v rámci metody `LeanMapper\Repository::createFluent()` - kvůli tomu nemůžou obdržet parametry předávané pomocí [auto-wiringu](#toc-parametry-filtru-auto-wiring). Využití naleznou např. pro soft-deleted entity a další podobné případy.
 
 K definici implicitních filtrů slouží metoda `LeanMapper\IMapper::getImplicitFilters`, která vrací buď pole s názvy filtrů, nebo instanci objektu `LeanMapper\ImplicitFilters` - ta může kromě názvů obsahovat i [adresované parametry](#toc-parametry-filtru-adresovane), které se mají filtrům předat.
 


### PR DESCRIPTION
* changelog rozšířen o změny ve vývojové verzi
* stránka Entity - opraveno drobné typo
* stránka Filtry - oprava chyb (objekt Caller může obsahovat odkaz na Property a ne její název; implicitní filtry se spouští i při traverzování mezi entitami nejen pro `Repository::createFluent`)